### PR TITLE
fix(terraform): add concurrency control to prevent state lock content…

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - "terraform/**"
 
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   terraform-dev:


### PR DESCRIPTION
Closes #17

## Summary
Resolved Terraform state lock contention caused by concurrent pipeline executions.

## Changes
- Added GitHub Actions concurrency control to prevent parallel Terraform runs
- Ensured serialized execution per branch

## Impact
- Eliminates "state blob is already locked" errors
- Improves deployment stability

## Validation
- Terraform runs execute sequentially
- No concurrent execution observed in pipeline