### PR TITLE
Fix Terraform resource dependency ordering issue

### DIFF
--- a/docs/terraform-dependencies.md
+++ b/docs/terraform-dependencies.md
@@ -1,0 +1,11 @@
+# Terraform Dependency Handling
+
+## Problem
+Terraform apply failed due to resource creation order issues.
+
+## Fix
+Used explicit `depends_on` to enforce resource creation order.
+
+## Example
+```hcl
+depends_on = [azurerm_virtual_network.vnet]

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -9,6 +9,9 @@ module "plan" {
   name                = var.app_service_plan_name
   location            = var.location
   resource_group_name = module.rg.name
+  depends_on = [
+    module.rg
+  ]
 }
 
 module "backend_api" {
@@ -22,6 +25,9 @@ module "backend_api" {
   db_name     = "EbookTest"
   db_user     = var.postgres_admin_user
   db_password = var.postgres_admin_password
+  depends_on = [
+    module.postgres
+  ]
 }
 
 module "backend_admin" {
@@ -35,6 +41,9 @@ module "backend_admin" {
   db_name     = "EbookTest"
   db_user     = var.postgres_admin_user
   db_password = var.postgres_admin_password
+  depends_on = [
+    module.postgres
+  ]
 }
 
 module "frontend_client" {


### PR DESCRIPTION
## Summary
Resolved Terraform deployment failures caused by missing explicit resource dependencies.

## Changes
- Added depends_on to critical Azure resources
- Improved resource creation order stability
- Added documentation for dependency handling

## Validation
- terraform apply runs successfully without intermittent failures

## Related Issue
Closes #23